### PR TITLE
fix(PRO-989): wire real rent/ERV data into IC Memo calculations

### DIFF
--- a/src/app/api/dealscope/properties/[id]/export/pdf/route.ts
+++ b/src/app/api/dealscope/properties/[id]/export/pdf/route.ts
@@ -46,6 +46,9 @@ export async function GET(
       currency: deal.currency ?? "GBP",
       askingPrice: deal.askingPrice ?? undefined,
       guidePrice: deal.guidePrice ?? undefined,
+      // PSF rates for deriving annual rent figures when full ERV not in dataSources
+      currentRentPsf: deal.currentRentPsf ?? undefined,
+      marketRentPsf: deal.marketRentPsf ?? undefined,
     }, { confidential: true });
 
     // Dynamic import avoids Next.js static analysis rejecting react-dom/server in route handlers

--- a/src/lib/dealscope/calculations/equity.ts
+++ b/src/lib/dealscope/calculations/equity.ts
@@ -17,7 +17,8 @@ export function calculateEquityMultiple(property: Property): EquityMultipleResul
 
   const totalCostIn = purchasePrice + sdlt + legalFees + surveyFees + capexResult.capex;
 
-  const erv = property.erv || property.passingRent || (property.size || 0) * 28;
+  // Fallback ERV: use £20/sqft for secondary commercial (conservative market default)
+  const erv = property.erv || property.passingRent || (property.size || 0) * 20;
   const opex = erv * 0.15;
   const noi = erv - opex;
   const exitYield = 0.08;

--- a/src/lib/dealscope/calculations/irr.ts
+++ b/src/lib/dealscope/calculations/irr.ts
@@ -39,7 +39,8 @@ export function calculateIRR(property: Property): IRRResult {
 
   const totalVoidCost = Object.values(voidCosts).reduce((sum, val) => sum + val, 0);
 
-  const erv = property.erv || property.passingRent || (property.size || 0) * 28;
+  // Fallback ERV: use £20/sqft for secondary commercial (conservative market default)
+  const erv = property.erv || property.passingRent || (property.size || 0) * 20;
   const monthlyRent = erv / 12;
 
   const lettingCosts = {

--- a/src/lib/dealscope/exports/populate-ic-memo.ts
+++ b/src/lib/dealscope/exports/populate-ic-memo.ts
@@ -30,25 +30,58 @@ export interface DealSourceData {
   currency?: string;
   askingPrice?: number;
   guidePrice?: number;
+  // PSF rates from ScoutDeal model for deriving annual rents when assumptions not stored
+  currentRentPsf?: number;
+  marketRentPsf?: number;
+}
+
+// Unwrap assumption objects stored as { value: number, source: string }
+function unwrapAssumption(v: unknown): number | undefined {
+  if (v == null) return undefined;
+  if (typeof v === "number") return v > 0 ? v : undefined;
+  if (typeof v === "object" && v !== null && "value" in v) {
+    const val = (v as { value: unknown }).value;
+    return typeof val === "number" && val > 0 ? val : undefined;
+  }
+  return undefined;
 }
 
 function toProperty(deal: DealSourceData): Property {
   const ds = (deal.dataSources ?? {}) as Record<string, unknown>;
   const assumptions = ds.assumptions as Record<string, unknown> | undefined;
+  const ai = ds.ai as Record<string, unknown> | undefined;
+  const size = deal.buildingSizeSqft ?? deal.sqft;
+
+  // Passing rent: dataSources direct → assumptions (unwrapped) → currentRentPsf * size → AI
+  const passingRent =
+    unwrapAssumption(ds.passingRent) ??
+    unwrapAssumption(ds.currentRentPa) ??
+    unwrapAssumption(assumptions?.passingRent) ??
+    (deal.currentRentPsf != null && size ? deal.currentRentPsf * size : undefined) ??
+    unwrapAssumption(ai?.passingRent);
+
+  // ERV: dataSources direct → assumptions (unwrapped) → marketRentPsf * size → AI
+  const erv =
+    unwrapAssumption(ds.erv) ??
+    unwrapAssumption(ds.marketRentPa) ??
+    unwrapAssumption(assumptions?.erv) ??
+    (deal.marketRentPsf != null && size ? deal.marketRentPsf * size : undefined) ??
+    unwrapAssumption(ai?.erv);
+
   return {
     id: deal.id,
     address: deal.address,
     assetType: deal.assetType,
     askingPrice: deal.askingPrice ?? deal.guidePrice,
-    size: deal.buildingSizeSqft ?? deal.sqft,
+    size,
     builtYear: deal.yearBuilt,
     epcRating: deal.epcRating,
     occupancyPct: deal.occupancyPct,
-    passingRent: (ds.passingRent ?? ds.currentRentPa ?? assumptions?.passingRent) as number | undefined,
-    erv: (ds.erv ?? ds.marketRentPa ?? assumptions?.erv) as number | undefined,
-    businessRates: (ds.businessRates ?? assumptions?.businessRates) as number | undefined,
-    serviceCharge: (ds.serviceCharge ?? assumptions?.serviceCharge) as number | undefined,
-    expectedVoid: (assumptions?.expectedVoidMonths ?? ds.expectedVoidMonths) as number | undefined,
+    passingRent,
+    erv,
+    businessRates: unwrapAssumption(ds.businessRates) ?? unwrapAssumption(assumptions?.businessRates),
+    serviceCharge: unwrapAssumption(ds.serviceCharge) ?? unwrapAssumption(assumptions?.serviceCharge),
+    expectedVoid: unwrapAssumption(assumptions?.expectedVoidMonths) ?? unwrapAssumption(ds.expectedVoidMonths),
     description: deal.dataSources ? JSON.stringify(deal.dataSources).toLowerCase() : undefined,
   };
 }


### PR DESCRIPTION
## Root cause analysis

The IC Memo was showing wrong financial figures (yield, ERV, IRR) because of three data bugs:

### Bug 1 — Assumption objects not unwrapped
The enrichment pipeline stores assumptions as `{ value: number, source: string }` objects:
```json
{ "assumptions": { "erv": { "value": 663300, "source": "market" } } }
```
But `toProperty()` in `populate-ic-memo.ts` tried to read `assumptions.erv` as a plain number. It always got `undefined`, so fell through to the broken fallback.

**Fix:** Added `unwrapAssumption()` helper that handles both `{ value, source }` objects and plain numbers.

### Bug 2 — PSF rent rates from model never used  
`ScoutDeal` has `currentRentPsf` and `marketRentPsf` columns that the enrichment pipeline populates (e.g. `22.00` for £22/sqft). These were never passed to `populateICMemo`, so rent derivation from `psf × sqft` was impossible.

**Fix:** Added `currentRentPsf`/`marketRentPsf` to `DealSourceData`; route passes them; `toProperty` derives annual rent = psf × buildingSizeSqft as a fallback.

### Bug 3 — Fallback ERV £28/sqft too high
If no rent data is available at all, `irr.ts` and `equity.ts` fell back to `size × 28`. For a 30,150 sqft Basildon office, that's £844k ERV — ~25% above market (£22-24 psf). Changed to £20/sqft (conservative secondary commercial default).

## Data flow after fix
```
passingRent =
  ds.passingRent (direct) ??
  ds.currentRentPa ??
  assumptions.passingRent.value (unwrapped) ??
  deal.currentRentPsf × sqft ??
  ai.passingRent
```

## Test plan
- [ ] Export IC Memo for `/scope/property/cmnmcfvb8000004jox5no7xt7`
- [ ] Financial Analysis page shows sensible ERV (expect ~£22-24/sqft × sqft)
- [ ] Cap rate / NIY in range 7-9% for Basildon multi-let office
- [ ] IRR figure is not wildly different from what comps suggest
- [ ] No NaN or £0 values in financial metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)